### PR TITLE
Fix/http headers

### DIFF
--- a/abc-base/7.1/Dockerfile
+++ b/abc-base/7.1/Dockerfile
@@ -68,6 +68,8 @@ RUN set -x \
     /tmp/pear \
   # Fix permissions, because we run as www-data.
   && chmod 755 /var/lib/nginx /var/lib/nginx/tmp/ \
+  # Add global PHP configuration
+  && install -o root -g root -m 644 -t /usr/local/etc/php/ php/docker-php-global.ini \
   # Disable PHP-FPM access logging, because nginx already logs for us.
   && sed -i \
     -e 's/^access\.log/;access.log/g' \

--- a/abc-base/7.1/Dockerfile
+++ b/abc-base/7.1/Dockerfile
@@ -69,7 +69,7 @@ RUN set -x \
   # Fix permissions, because we run as www-data.
   && chmod 755 /var/lib/nginx /var/lib/nginx/tmp/ \
   # Add global PHP configuration
-  && install -o root -g root -m 644 -t /usr/local/etc/php/ php/docker-php-global.ini \
+  && install -o root -g root -m 644 -t /usr/local/etc/php/conf.d/ php/docker-php-global.ini \
   # Disable PHP-FPM access logging, because nginx already logs for us.
   && sed -i \
     -e 's/^access\.log/;access.log/g' \

--- a/abc-base/7.1/php/docker-php-global.ini
+++ b/abc-base/7.1/php/docker-php-global.ini
@@ -1,0 +1,4 @@
+; Any global PHP configuration can be added here.
+
+; Disable X-Powered-By header
+expose_php = Off

--- a/abc-base/7.2/Dockerfile
+++ b/abc-base/7.2/Dockerfile
@@ -68,6 +68,8 @@ RUN set -x \
     /tmp/pear \
   # Fix permissions, because we run as www-data.
   && chmod 755 /var/lib/nginx /var/lib/nginx/tmp/ \
+  # Add global PHP configuration
+  && install -o root -g root -m 644 -t /usr/local/etc/php/ php/docker-php-global.ini \
   # Disable PHP-FPM access logging, because nginx already logs for us.
   && sed -i \
     -e 's/^access\.log/;access.log/g' \

--- a/abc-base/7.2/Dockerfile
+++ b/abc-base/7.2/Dockerfile
@@ -69,7 +69,7 @@ RUN set -x \
   # Fix permissions, because we run as www-data.
   && chmod 755 /var/lib/nginx /var/lib/nginx/tmp/ \
   # Add global PHP configuration
-  && install -o root -g root -m 644 -t /usr/local/etc/php/ php/docker-php-global.ini \
+  && install -o root -g root -m 644 -t /usr/local/etc/php/conf.d/ php/docker-php-global.ini \
   # Disable PHP-FPM access logging, because nginx already logs for us.
   && sed -i \
     -e 's/^access\.log/;access.log/g' \

--- a/abc-base/7.2/php/docker-php-global.ini
+++ b/abc-base/7.2/php/docker-php-global.ini
@@ -1,0 +1,4 @@
+; Any global PHP configuration can be added here.
+
+; Disable X-Powered-By header
+expose_php = Off


### PR DESCRIPTION
This pull requests contains a fix for disabling the X-Powered-By header (PHP version exposure) for every project that uses Docker. This global PHP configuration file can also be used for other available configuration options.

JIRA: https://angrybytes.atlassian.net/browse/ABC-1278