### PR TITLE
nsd: fix logging of watch variant

### DIFF
--- a/nsd/4-watch/watch.sh
+++ b/nsd/4-watch/watch.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 set -e
 
-nsd
+nsd -d &
 
-exec inotifyd - "${ZONESDIR:-/etc/nsd}":wymd | \
+inotifyd - "${ZONESDIR:-/etc/nsd}":wymd | \
   while read; do
     while read -t 1; do true; done
     kill -SIGHUP $(cat "${PIDFILE:-/var/run/nsd.pid}")


### PR DESCRIPTION
Background using the shell, instead of using the daemonization feature of NSD itself. The latter tries to log using syslog, which doesn't work in Docker.