### PR TITLE
abc-base: add a PHP 7.3 variant

### DIFF
--- a/abc-base/7.3/Dockerfile
+++ b/abc-base/7.3/Dockerfile
@@ -1,0 +1,95 @@
+FROM php:7.3-fpm-alpine
+
+RUN set -x \
+  # Install dependencies and PHP extensions.
+  && apk update \
+  && apk add \
+    freetype \
+    gmp \
+    icu-libs \
+    libintl \
+    libjpeg-turbo \
+    libldap \
+    libmemcached \
+    libpng \
+    libsasl \
+    libwebp \
+    libzip \
+    nginx \
+    pcre \
+    postgresql-libs \
+    sqlite-libs \
+    tini \
+  && apk add --virtual .build-deps \
+    $PHPIZE_DEPS \
+    cyrus-sasl-dev \
+    freetype-dev \
+    gettext-dev \
+    gmp-dev \
+    icu-dev \
+    libjpeg-turbo-dev \
+    libmemcached-dev \
+    libpng-dev \
+    libwebp-dev \
+    libzip-dev \
+    openldap-dev \
+    pcre-dev \
+    postgresql-dev \
+    sqlite-dev \
+  && docker-php-ext-enable opcache \
+  && docker-php-ext-configure gd \
+    --with-webp-dir=/usr \
+    --with-jpeg-dir=/usr \
+    --with-png-dir=/usr \
+    --with-zlib-dir=/usr \
+    --with-freetype-dir=/usr \
+  && docker-php-ext-configure zip \
+    --with-zlib-dir=/usr \
+  && docker-php-ext-configure pdo_mysql \
+    --with-zlib-dir=/usr \
+  && docker-php-ext-install \
+    exif \
+    gd \
+    gettext \
+    gmp \
+    intl \
+    ldap \
+    mbstring \
+    pcntl \
+    pdo_mysql \
+    pdo_pgsql \
+    pdo_sqlite \
+    zip \
+  # FIXME: Add memcached once compatible.
+  # https://github.com/php-memcached-dev/php-memcached/issues/408
+  && pecl install \
+    redis \
+  && docker-php-ext-enable \
+    redis \
+  # Cleanup.
+  && apk del .build-deps \
+  && rm -r \
+    /var/cache/apk/* \
+    /tmp/pear \
+  # Fix permissions, because we run as www-data.
+  && chmod 755 /var/lib/nginx /var/lib/nginx/tmp/ \
+  # Disable PHP-FPM access logging, because nginx already logs for us.
+  && sed -i \
+    -e 's/^access\.log/;access.log/g' \
+    /usr/local/etc/php-fpm.d/docker.conf
+
+# Configure PHP.
+COPY php/ /usr/local/etc/php/conf.d/
+
+# Configure nginx.
+EXPOSE 80
+COPY nginx/ /etc/nginx/
+
+# Add the entry script, starting nginx and php-fpm.
+# Use tini, so nginx reparents itself to a proper init.
+COPY bin/ /usr/local/bin/
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["abc-start"]
+
+# Config and data shared between project versions.
+VOLUME /shared

--- a/abc-base/7.3/Dockerfile
+++ b/abc-base/7.3/Dockerfile
@@ -73,13 +73,12 @@ RUN set -x \
     /tmp/pear \
   # Fix permissions, because we run as www-data.
   && chmod 755 /var/lib/nginx /var/lib/nginx/tmp/ \
-  # Disable PHP-FPM access logging, because nginx already logs for us.
-  && sed -i \
-    -e 's/^access\.log/;access.log/g' \
-    /usr/local/etc/php-fpm.d/docker.conf
+  # Remove PHP FPM config, because we'll replace it.
+  && rm -fr /usr/local/etc/php-fpm.*
 
-# Configure PHP.
+# Configure PHP and PHP FPM.
 COPY php/ /usr/local/etc/php/conf.d/
+COPY php-fpm.conf /usr/local/etc/
 
 # Configure nginx.
 EXPOSE 80

--- a/abc-base/7.3/bin/abc-link-shared
+++ b/abc-base/7.3/bin/abc-link-shared
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+# Small helper that takes a list of docroot-relative paths, and sets them up as
+# symlinks to the shared volume.
+#
+# By default, creates links in `/var/www/html` to `/shared`, but these can be
+# overridden with the `PROJECT_ROOT` and `SHARED_ROOT` environment variables.
+#
+# Note that the `PROJECT_ROOT` paths are trashed.
+
+SHARED_ROOT="${SHARED_ROOT:-/shared}"
+PROJECT_ROOT="${PROJECT_ROOT:-/var/www/html}"
+
+for f in "$@"; do
+  echo "${PROJECT_ROOT}/${f} -> ${SHARED_ROOT}/${f}"
+  rm -fr "${PROJECT_ROOT}/${f}"
+  ln -s "${SHARED_ROOT}/${f}" "${PROJECT_ROOT}/${f}"
+done

--- a/abc-base/7.3/bin/abc-start
+++ b/abc-base/7.3/bin/abc-start
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# The container entry-point. Starts nginx and php-fpm. Assumes it's running in
+# the project root, and tini (or another proper init system) is PID 1.
+
+nginx
+exec php-fpm

--- a/abc-base/7.3/nginx/abc_vhost
+++ b/abc-base/7.3/nginx/abc_vhost
@@ -1,0 +1,16 @@
+# This file is meant to be included in ABC Manager vhosts. It proxies *.php
+# requests to PHP FPM, and sets up rewriting to index.php.
+
+index  index.php index.html;
+
+location / {
+  try_files  $uri $uri/ /index.php$is_args$args;
+}
+
+location ~ \.php$ {
+  include  fastcgi_params;
+
+  fastcgi_pass  localhost:9000;
+  fastcgi_index  index.php;
+  fastcgi_param  SCRIPT_FILENAME $document_root$fastcgi_script_name;
+}

--- a/abc-base/7.3/nginx/abc_vhost
+++ b/abc-base/7.3/nginx/abc_vhost
@@ -10,7 +10,7 @@ location / {
 location ~ \.php$ {
   include  fastcgi_params;
 
-  fastcgi_pass  localhost:9000;
+  fastcgi_pass  unix:/var/run/php-fpm.sock;
   fastcgi_index  index.php;
   fastcgi_param  SCRIPT_FILENAME $document_root$fastcgi_script_name;
 }

--- a/abc-base/7.3/nginx/conf.d/default.conf
+++ b/abc-base/7.3/nginx/conf.d/default.conf
@@ -1,0 +1,8 @@
+# Default vhost, simply closes the connection.
+server {
+  listen  80 default_server;
+  listen  [::]:80 default_server;
+  server_name  _;
+
+  return  444;
+}

--- a/abc-base/7.3/nginx/nginx.conf
+++ b/abc-base/7.3/nginx/nginx.conf
@@ -1,0 +1,31 @@
+user  www-data;
+worker_processes  1;
+
+error_log  /dev/stderr warn;
+pid  /nginx.pid;
+
+events {
+  worker_connections  1024;
+}
+
+http {
+  include  /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  access_log  /dev/stdout combined;
+
+  sendfile  on;
+  tcp_nopush  on;
+  tcp_nodelay  on;
+  gzip_static  on;
+  server_tokens  off;
+
+  # Disable tasks handled by front proxies.
+  proxy_buffering  off;
+  proxy_request_buffering  off;
+  fastcgi_buffering  off;
+  fastcgi_request_buffering  off;
+  client_max_body_size  0;
+
+  include /etc/nginx/conf.d/*.conf;
+}

--- a/abc-base/7.3/php-fpm.conf
+++ b/abc-base/7.3/php-fpm.conf
@@ -1,0 +1,18 @@
+[global]
+daemonize = no
+error_log = /proc/self/fd/2
+
+[www]
+user = www-data
+group = www-data
+
+listen = /var/run/php-fpm.sock
+
+clear_env = no
+catch_workers_output = yes
+
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3

--- a/abc-base/7.3/php/docker-php-global.ini
+++ b/abc-base/7.3/php/docker-php-global.ini
@@ -1,0 +1,4 @@
+; Any global PHP configuration can be added here.
+
+; Disable X-Powered-By header
+expose_php = Off


### PR DESCRIPTION
Differences from 7.2:

 - libzip is apparently not in the base images, so we install it.
 - memcached ext is not yet compatible, temporarily disabled.
 - We now configure PHP FPM to use unix sockets only by default.