### PR TITLE
abc-base: disable decorate_workers_output

### DIFF
--- a/abc-base/8.0/php-fpm.conf
+++ b/abc-base/8.0/php-fpm.conf
@@ -11,6 +11,7 @@ listen.group = www-data
 
 clear_env = no
 catch_workers_output = yes
+decorate_workers_output = no
 
 pm = dynamic
 pm.max_children = 5


### PR DESCRIPTION
Normally PHP-FPM decorates output as follows:

```
[11-Jun-2021 09:54:27] WARNING: [pool www] child 70 said into stderr: "test"
```

Disabling this helps with container logging to stderr, resulting in just:

```
test
```