### PR TITLE
Add Debian bullseye based images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,9 @@ jobs:
         - "abc-base:7.3-buster"
         - "abc-base:7.4"
         - "abc-base:7.4-buster"
+        - "abc-base:7.4-bullseye"
         - "abc-base:8.0"
+        - "abc-base:8.0-bullseye"
         - "abc-base:8.1-rc"
     steps:
 

--- a/abc-base/7.4-bullseye/Dockerfile
+++ b/abc-base/7.4-bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-rc-fpm-bullseye
+FROM php:7.4-fpm-bullseye
 
 # Install dependencies and PHP extensions.
 RUN set -x \

--- a/abc-base/7.4-bullseye/bin/abc-link-shared
+++ b/abc-base/7.4-bullseye/bin/abc-link-shared
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+# Small helper that takes a list of docroot-relative paths, and sets them up as
+# symlinks to the shared volume.
+#
+# By default, creates links in `/var/www/html` to `/shared`, but these can be
+# overridden with the `PROJECT_ROOT` and `SHARED_ROOT` environment variables.
+#
+# Note that the `PROJECT_ROOT` paths are trashed.
+
+SHARED_ROOT="${SHARED_ROOT:-/shared}"
+PROJECT_ROOT="${PROJECT_ROOT:-/var/www/html}"
+
+for f in "$@"; do
+  echo "${PROJECT_ROOT}/${f} -> ${SHARED_ROOT}/${f}"
+  rm -fr "${PROJECT_ROOT}/${f}"
+  ln -s "${SHARED_ROOT}/${f}" "${PROJECT_ROOT}/${f}"
+done

--- a/abc-base/7.4-bullseye/bin/abc-start
+++ b/abc-base/7.4-bullseye/bin/abc-start
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# The container entry-point. Starts nginx and php-fpm. Assumes it's running in
+# the project root, and tini (or another proper init system) is PID 1.
+
+nginx
+exec php-fpm

--- a/abc-base/7.4-bullseye/nginx/abc_vhost
+++ b/abc-base/7.4-bullseye/nginx/abc_vhost
@@ -1,0 +1,16 @@
+# This file is meant to be included in ABC Manager vhosts. It proxies *.php
+# requests to PHP FPM, and sets up rewriting to index.php.
+
+index  index.php index.html;
+
+location / {
+  try_files  $uri $uri/ /index.php$is_args$args;
+}
+
+location ~ \.php$ {
+  include  fastcgi_params;
+
+  fastcgi_pass  unix:/var/run/php-fpm.sock;
+  fastcgi_index  index.php;
+  fastcgi_param  SCRIPT_FILENAME $document_root$fastcgi_script_name;
+}

--- a/abc-base/7.4-bullseye/nginx/conf.d/default.conf
+++ b/abc-base/7.4-bullseye/nginx/conf.d/default.conf
@@ -1,0 +1,8 @@
+# Default vhost, simply closes the connection.
+server {
+  listen  80 default_server;
+  listen  [::]:80 default_server;
+  server_name  _;
+
+  return  444;
+}

--- a/abc-base/7.4-bullseye/nginx/nginx.conf
+++ b/abc-base/7.4-bullseye/nginx/nginx.conf
@@ -1,0 +1,31 @@
+user  www-data;
+worker_processes  1;
+
+error_log  /dev/stderr warn;
+pid  /nginx.pid;
+
+events {
+  worker_connections  1024;
+}
+
+http {
+  include  /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  access_log  /dev/stdout combined;
+
+  sendfile  on;
+  tcp_nopush  on;
+  tcp_nodelay  on;
+  gzip_static  on;
+  server_tokens  off;
+
+  # Disable tasks handled by front proxies.
+  proxy_buffering  off;
+  proxy_request_buffering  off;
+  fastcgi_buffering  off;
+  fastcgi_request_buffering  off;
+  client_max_body_size  0;
+
+  include /etc/nginx/conf.d/*.conf;
+}

--- a/abc-base/7.4-bullseye/php-fpm.conf
+++ b/abc-base/7.4-bullseye/php-fpm.conf
@@ -1,0 +1,19 @@
+[global]
+daemonize = no
+error_log = /proc/self/fd/2
+
+[www]
+user = www-data
+group = www-data
+
+listen = /var/run/php-fpm.sock
+listen.group = www-data
+
+clear_env = no
+catch_workers_output = yes
+
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3

--- a/abc-base/7.4-bullseye/php/docker-php-global.ini
+++ b/abc-base/7.4-bullseye/php/docker-php-global.ini
@@ -1,0 +1,4 @@
+; Any global PHP configuration can be added here.
+
+; Disable X-Powered-By header
+expose_php = Off

--- a/abc-base/8.0-bullseye/Dockerfile
+++ b/abc-base/8.0-bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-rc-fpm-bullseye
+FROM php:8.0-fpm-bullseye
 
 # Install dependencies and PHP extensions.
 RUN set -x \

--- a/abc-base/8.0-bullseye/bin/abc-link-shared
+++ b/abc-base/8.0-bullseye/bin/abc-link-shared
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+# Small helper that takes a list of docroot-relative paths, and sets them up as
+# symlinks to the shared volume.
+#
+# By default, creates links in `/var/www/html` to `/shared`, but these can be
+# overridden with the `PROJECT_ROOT` and `SHARED_ROOT` environment variables.
+#
+# Note that the `PROJECT_ROOT` paths are trashed.
+
+SHARED_ROOT="${SHARED_ROOT:-/shared}"
+PROJECT_ROOT="${PROJECT_ROOT:-/var/www/html}"
+
+for f in "$@"; do
+  echo "${PROJECT_ROOT}/${f} -> ${SHARED_ROOT}/${f}"
+  rm -fr "${PROJECT_ROOT}/${f}"
+  ln -s "${SHARED_ROOT}/${f}" "${PROJECT_ROOT}/${f}"
+done

--- a/abc-base/8.0-bullseye/bin/abc-start
+++ b/abc-base/8.0-bullseye/bin/abc-start
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# The container entry-point. Starts nginx and php-fpm. Assumes it's running in
+# the project root, and tini (or another proper init system) is PID 1.
+
+nginx
+exec php-fpm

--- a/abc-base/8.0-bullseye/nginx/abc_vhost
+++ b/abc-base/8.0-bullseye/nginx/abc_vhost
@@ -1,0 +1,16 @@
+# This file is meant to be included in ABC Manager vhosts. It proxies *.php
+# requests to PHP FPM, and sets up rewriting to index.php.
+
+index  index.php index.html;
+
+location / {
+  try_files  $uri $uri/ /index.php$is_args$args;
+}
+
+location ~ \.php$ {
+  include  fastcgi_params;
+
+  fastcgi_pass  unix:/var/run/php-fpm.sock;
+  fastcgi_index  index.php;
+  fastcgi_param  SCRIPT_FILENAME $document_root$fastcgi_script_name;
+}

--- a/abc-base/8.0-bullseye/nginx/conf.d/default.conf
+++ b/abc-base/8.0-bullseye/nginx/conf.d/default.conf
@@ -1,0 +1,8 @@
+# Default vhost, simply closes the connection.
+server {
+  listen  80 default_server;
+  listen  [::]:80 default_server;
+  server_name  _;
+
+  return  444;
+}

--- a/abc-base/8.0-bullseye/nginx/nginx.conf
+++ b/abc-base/8.0-bullseye/nginx/nginx.conf
@@ -1,0 +1,31 @@
+user  www-data;
+worker_processes  1;
+
+error_log  /dev/stderr warn;
+pid  /nginx.pid;
+
+events {
+  worker_connections  1024;
+}
+
+http {
+  include  /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  access_log  /dev/stdout combined;
+
+  sendfile  on;
+  tcp_nopush  on;
+  tcp_nodelay  on;
+  gzip_static  on;
+  server_tokens  off;
+
+  # Disable tasks handled by front proxies.
+  proxy_buffering  off;
+  proxy_request_buffering  off;
+  fastcgi_buffering  off;
+  fastcgi_request_buffering  off;
+  client_max_body_size  0;
+
+  include /etc/nginx/conf.d/*.conf;
+}

--- a/abc-base/8.0-bullseye/php-fpm.conf
+++ b/abc-base/8.0-bullseye/php-fpm.conf
@@ -1,0 +1,20 @@
+[global]
+daemonize = no
+error_log = /proc/self/fd/2
+
+[www]
+user = www-data
+group = www-data
+
+listen = /var/run/php-fpm.sock
+listen.group = www-data
+
+clear_env = no
+catch_workers_output = yes
+decorate_workers_output = no
+
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3

--- a/abc-base/8.0-bullseye/php/docker-php-global.ini
+++ b/abc-base/8.0-bullseye/php/docker-php-global.ini
@@ -1,0 +1,4 @@
+; Any global PHP configuration can be added here.
+
+; Disable X-Powered-By header
+expose_php = Off


### PR DESCRIPTION
For 7.4 and 8.0, essentially a copy. For 8.1-rc, we switch base. 7.3 is EOL soon any way.